### PR TITLE
chore: Use base image from registry.centos.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM registry.centos.org/centos/centos:7
 
 LABEL maintainer="Sunil Samal <ssamal@redhat.com>"
 


### PR DESCRIPTION
Docker hub has a pull limit,hence we need a different registry to pull images.